### PR TITLE
Fixed typo in 0O (zero, oh) code to match keripy

### DIFF
--- a/spec/spec.md
+++ b/spec/spec.md
@@ -1126,7 +1126,7 @@ This master table includes both the Primitive and Count Code types. The types ar
 |    `0L`    | Tag5 5 B64 encoded chars + 1 prepad for for special values     |      2      |        6      |       8     |
 |    `0M`    | Tag6 6 B64 encoded chars for for special values  |      2      |      6        |       8     |
 |    `0N`    | Tag9 9 B64 encoded chars + 1 prepad for special values |      2      |       10       |       12     |
-|    `0N`    | Tag10 10 B64 encoded chars for special values |      2      |      10        |       12     |
+|    `0O`    | Tag10 10 B64 encoded chars for special values |      2      |      10        |       12     |
 |            |  Basic Four Character Codes   |             |              |              |
 |   `1AAA`   | ECDSA secp256k1 non-transferable prefix public verification key   |      4      |              |      48      |
 |   `1AAB`   | ECDSA secp256k1 public verification or encryption key |      4      |              |      48      |


### PR DESCRIPTION
Fixed typo in 0O (zero, oh) two character fixed code to match keripy.