### PR TITLE
docs: correct SAIDs

### DIFF
--- a/spec/spec.md
+++ b/spec/spec.md
@@ -1456,20 +1456,20 @@ The `dict` is then serialized into JSON with no extra whitespace. The serializat
 The Blake3-256 digest is then computed on that serialization above and encoded in CESR to provide the SAID as follows:
 
 ```
-EnKa0ALimLL8eQdZGzglJG_SxvncxkmvwFDhIyLFchUk
+EJymtAC4piy_HkHWRs4JSRv0sb53MZJr8BQ4SMixXIVJ
 ```
 
 The value of the `said` field is now replaced with the computed and encoded SAID to produce the final serialization with embedded SAID as follows:
 
 ```json
-{"said":"EnKa0ALimLL8eQdZGzglJG_SxvncxkmvwFDhIyLFchUk","first":"Sue","last":"Smith","role":"Founder"}
+{"said":"EJymtAC4piy_HkHWRs4JSRv0sb53MZJr8BQ4SMixXIVJ","first":"Sue","last":"Smith","role":"Founder"}
 ```
 
 The final serialization may be converted to a python `dict` by deserializing the JSON to produce:
 
 ```python
 {
-    "said": "EnKa0ALimLL8eQdZGzglJG_SxvncxkmvwFDhIyLFchUk",
+    "said": "EJymtAC4piy_HkHWRs4JSRv0sb53MZJr8BQ4SMixXIVJ",
     "first": "Sue",
     "last": "Smith",
     "role": "Founder"
@@ -1508,7 +1508,7 @@ Third, replace the dummy identifier value with the derived identifier value in t
 
 ```json
     {
-        "$id": "EZT9Idj7zLA0Ek6o8oevixdX20607CljNg4zrf_NQINY",
+        "$id": "EGU_SHY-8ywNBJOqPKHr4sXV9tOtOwpYzYOM63_zUCDW",
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",
         "properties": {


### PR DESCRIPTION
I calculated the SAIDs here with KERIpy and got the SAIDs in this changeset.

Here are the tests to generate the SAIDs I did (put the tests in `test_coring.py` and run them for reference).

```python
def test_said_1():
    code = MtrDex.Blake3_256
    ser = b'{"said":"############################################","first":"Sue","last":"Smith","role":"Founder"}'
    saider, sad = Saider.saidify(sad=json.loads(ser), code=code, label='said')
    assert saider.qb64 == 'EJymtAC4piy_HkHWRs4JSRv0sb53MZJr8BQ4SMixXIVJ'

def test_said_2():
    code = MtrDex.Blake3_256
    ser = b'{"$id": "############################################","$schema": "http://json-schema.org/draft-07/schema#","type": "object","properties": {"full_name": {"type": "string"}}}'
    saider, sad = Saider.saidify(sad=json.loads(ser), code=code, label='$id')
    assert saider.qb64 == 'EGU_SHY-8ywNBJOqPKHr4sXV9tOtOwpYzYOM63_zUCDW'
```