### PR TITLE
fix: rapid scroll bug fixed by v1.6.21 of Spec Up T

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache 2.0",
       "dependencies": {
         "dotenv": "^16.4.5",
-        "spec-up-t": "^1.6.0"
+        "spec-up-t": "^1.6.21"
       }
     },
     "node_modules/@asamuzakjp/css-color": {
@@ -799,13 +799,49 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/axios": {
-      "version": "1.13.6",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
-      "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
+      "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
+      "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/axios/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/axios/node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/b4a": {
@@ -1511,9 +1547,10 @@
       "integrity": "sha512-XxtPuC3PGakY6PD7dG66/o8KwJ/LkH2/EKe19Dcw58w53dv4/vSQEkn/SzuyhHE2q4zPgCkxQBxus3VV4ql+Pg=="
     },
     "node_modules/diff": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.3.tgz",
-      "integrity": "sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==",
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
+      "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
       }
@@ -1954,15 +1991,16 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
           "url": "https://github.com/sponsors/RubenVerborgh"
         }
       ],
+      "license": "MIT",
       "engines": {
         "node": ">=4.0"
       },
@@ -4195,21 +4233,22 @@
       }
     },
     "node_modules/spec-up-t": {
-      "version": "1.6.9",
-      "resolved": "https://registry.npmjs.org/spec-up-t/-/spec-up-t-1.6.9.tgz",
-      "integrity": "sha512-Y28i6xcVzVViqDlM8BBvOVv/MlVgg9gYu/cZhtS3pM2KSDEO9RAXhS1sUdQHAeIH0NCpx2oywRxUWm5FUlGiZw==",
+      "version": "1.6.21",
+      "resolved": "https://registry.npmjs.org/spec-up-t/-/spec-up-t-1.6.21.tgz",
+      "integrity": "sha512-G50C6KYZcop/pQATeVV6djydToTnnxfAYWiTQY72VeCHPg9UFelfZ+k5Gqj8OJPk2eEy5nVmtUX7N3D74hBoWw==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@octokit/plugin-throttling": "^9.4.0",
+        "@octokit/plugin-throttling": "^9.6.1",
         "@traptitech/markdown-it-katex": "^3.3.0",
-        "axios": "^1.7.7",
+        "axios": "^1.15.0",
         "chalk": "^4.1.2",
-        "cheerio": "^1.1.2",
-        "dedent": "^1.5.3",
-        "diff": "^8.0.3",
+        "cheerio": "^1.2.0",
+        "dedent": "^1.7.2",
+        "diff": "^8.0.4",
         "docx": "^8.5.0",
-        "dotenv": "^16.4.7",
+        "dotenv": "^16.6.1",
         "find-pkg-dir": "^2.0.0",
-        "fs-extra": "^11.3.0",
+        "fs-extra": "^11.3.4",
         "gulp": "^5.0.1",
         "gulp-clean-css": "4.3.0",
         "gulp-concat": "2.6.1",
@@ -4234,13 +4273,13 @@
         "markdown-it-textual-uml": "^0.1.3",
         "markdown-it-toc-and-anchor": "^4.2.0",
         "merge-stream": "^2.0.0",
-        "octokit": "^4.1.0",
+        "octokit": "^4.1.4",
         "pdf-lib": "^1.17.1",
         "pkg-dir": "^8.0.0",
         "prismjs": "^1.24.0",
         "puppeteer": "^23.2.1",
         "readline-sync": "^1.4.10",
-        "spec-up-t-healthcheck": "^1.0.0",
+        "spec-up-t-healthcheck": "^1.1.2",
         "yargs": "^17.7.2"
       }
     },

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Technical specification drafting tool that generates rich specification documents from markdown.",
   "dependencies": {
     "dotenv": "^16.4.5",
-    "spec-up-t": "^1.6.0"
+    "spec-up-t": "^1.6.21"
   },
   "author": "Daniel Buchner",
   "repository": {


### PR DESCRIPTION
Closes #167.

Updates `spec-up-t` from `^1.6.0` to `^1.6.21` and refreshes the npm lockfile, matching trustoverip/kswg-did-method-webs-specification#207.

Validation:
- `npm ci`
- `npm ls spec-up-t --depth=0`
- `npm run render`
