### PR TITLE
chore: update Spec-Up-T to v1.6.25 (fixed version)

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Technical specification drafting tool that generates rich specification documents from markdown.",
   "dependencies": {
     "dotenv": "^16.4.5",
-    "spec-up-t": "^1.6.21"
+    "spec-up-t": "1.6.25"
   },
   "author": "Daniel Buchner",
   "repository": {


### PR DESCRIPTION
Fix due to problem with spec-up-t version 1.6.26: setting version to 1.2.25 (without `^`).